### PR TITLE
Switch to pointer method receiver

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -73,7 +73,7 @@ func (u UUID) MarshalBinary() ([]byte, error) {
 	return u[:], nil
 }
 
-func (u UUID) UnmarshalBinary(data []byte) error {
+func (u *UUID) UnmarshalBinary(data []byte) error {
 	if len(data) < len(u) {
 		return errors.New("invalid length")
 	}


### PR DESCRIPTION
Receiving by value here won't apply any changes to the underlying
UUID we would ordinarily want to unmarshal to.